### PR TITLE
Remote movement sequences

### DIFF
--- a/scripts/connect_bluetooth.py
+++ b/scripts/connect_bluetooth.py
@@ -194,6 +194,7 @@ class Bulebule(cmd.Cmd):
     prompt = '>>> '
     LOG_SUBCOMMANDS = ['all', 'clear', 'save']
     PLOT_SUBCOMMANDS = ['linear_speed_profile', 'angular_speed_profile']
+    MOVE_SUBCOMMANDS = ['O', 'F', 'L', 'R', 'B', 'M', 'H', 'E', 'l', 'r', 'b']
     RUN_SUBCOMMANDS = [
         'angular_speed_profile',
         'linear_speed_profile',
@@ -294,6 +295,14 @@ class Bulebule(cmd.Cmd):
         else:
             print('Please, specify what to run!')
 
+    def do_move(self, extra):
+        """Execute a series of movements."""
+        if all(movement in self.MOVE_SUBCOMMANDS for movement in set(extra)):
+            self.proxy.send_bt('move %s\0' % extra)
+        else:
+            print('Please, specify a valid movement sequence!')
+            print('{}'.format(self.MOVE_SUBCOMMANDS))
+
     def complete_log(self, text, line, begidx, endidx):
         return complete_subcommands(text, self.LOG_SUBCOMMANDS)
 
@@ -302,6 +311,9 @@ class Bulebule(cmd.Cmd):
 
     def complete_run(self, text, line, begidx, endidx):
         return complete_subcommands(text, self.RUN_SUBCOMMANDS)
+
+    def complete_move(self, text, line, begidx, endidx):
+        return self.MOVE_SUBCOMMANDS
 
     def complete_set(self, text, line, begidx, endidx):
         return complete_subcommands(text, self.SET_SUBCOMMANDS)

--- a/src/calibration.c
+++ b/src/calibration.c
@@ -87,6 +87,9 @@ void run_static_turn_right_profile(void)
  * - 'M': to stop at the middle of the cell.
  * - 'H': to stop touching the front wall of the cell.
  * - 'E': to stop at the end of the cell.
+ * - 'l': to turn left (in place).
+ * - 'r': to turn right (in place).
+ * - 'b': to turn back (in place).
  */
 void run_movement_sequence(const char *sequence)
 {
@@ -123,6 +126,15 @@ void run_movement_sequence(const char *sequence)
 			break;
 		case 'E':
 			stop_end();
+			break;
+		case 'l':
+			turn_left();
+			break;
+		case 'r':
+			turn_right();
+			break;
+		case 'b':
+			turn_back();
 			break;
 		default:
 			break;

--- a/src/serial.c
+++ b/src/serial.c
@@ -11,6 +11,7 @@ static bool run_angular_speed_profile_signal;
 static bool run_linear_speed_profile_signal;
 static bool run_static_turn_right_profile_signal;
 static bool run_front_sensors_calibration_signal;
+static char run_movement_sequence_signal[BUFFER_SIZE];
 
 /**
  * @brief Push a single char to the serial received buffer.
@@ -99,6 +100,8 @@ static void process_command(void)
 		run_static_turn_right_profile_signal = true;
 	else if (!strcmp(buffer.data, "run front_sensors_calibration"))
 		run_front_sensors_calibration_signal = true;
+	else if (starts_with("move "))
+		strcpy(run_movement_sequence_signal, buffer.data);
 	else if (starts_with("set micrometers_per_count "))
 		set_micrometers_per_count(parse_spaced_float(2));
 	else if (starts_with("set wheels_separation "))
@@ -170,5 +173,8 @@ void execute_commands(void)
 	} else if (run_front_sensors_calibration_signal) {
 		run_front_sensors_calibration_signal = false;
 		run_front_sensors_calibration();
+	} else if (strlen(run_movement_sequence_signal)) {
+		run_movement_sequence(run_movement_sequence_signal);
+		run_movement_sequence_signal[0] = '\0';
 	}
 }


### PR DESCRIPTION
In example:

```
move OFRM
```

Results in the mouse moving out of initial cell, front 1 cell, turn right and stop at the middle of the next cell.